### PR TITLE
[docs]: Update cu_dbmi.md to remove link to Research Informatics' Slack workspace

### DIFF
--- a/docs/cu_dbmi.md
+++ b/docs/cu_dbmi.md
@@ -3,8 +3,8 @@
 As a new member of the lab, you're also a member of the CU Department of Biomedical Informatics (DBMI).
 The list below contains a series of tasks that you will likely need to complete to fully join the DBMI.
 
-* **Request access to the [Research Informatics' Slack workspace](https://app.slack.com/client/T059SDTDE14)**.
-Many faculty members, postdocs and students are part of this workspace, and it is convenient to be in touch with the rest.
+* **Request access to the Research Informatics' Slack workspace**.
+Many faculty members, postdocs and students are part of this workspace, and it is convenient to be in touch with the rest. Please contact Milton to get an invitation to the workspace.
 * **Request access to the [Alpine Cluster](https://www.colorado.edu/rc/alpine).**
 If you're part of the lab, you'll likely need computational resources to run your experiments on large datasets.
 * **Setup the CU VPN in your laptop**


### PR DESCRIPTION
Remove the Slack link since it's no longer valid.